### PR TITLE
Replace soon-to-be deprecated \etex_iffontchar:D by \tex_iffontchar:D

### DIFF
--- a/docs/firamath-specimen.tex
+++ b/docs/firamath-specimen.tex
@@ -69,7 +69,7 @@
   { \tex_char:D \int_eval:n {#1} \scan_stop: }
 \prg_new_protected_conditional:Npnn \@@_if_char_exist:n #1 { T, F, TF }
   {
-    \etex_iffontchar:D \tex_font:D \int_eval:n {#1} \scan_stop:
+    \tex_iffontchar:D \tex_font:D \int_eval:n {#1} \scan_stop:
       \prg_return_true:
     \else:
       \prg_return_false:


### PR DESCRIPTION
By the end of 2019 the \etex_iffontchar:D will be removed. All the primitives are already named \tex_...:D and should be used instead.